### PR TITLE
fix: keep vpnbots on update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,6 +68,9 @@ _step_eta() {
         "Configuring Apache virtual hosts"*) echo 6  ;;
         "Creating database & user"*)         echo 5  ;;
         "Setting Telegram webhook"*)         echo 5  ;;
+        "Backing up vpnbots"*)               echo 5  ;;
+        "Restoring vpnbots"*)                echo 5  ;;
+        "Setting vpnbot webhooks"*)          echo 10 ;;
         "Initializing database tables"*)     echo 15 ;;
         *)                                   echo 8  ;;
     esac
@@ -1531,6 +1534,73 @@ purge_installer_dir() {
     return 0
 }
 
+# vpnbot instance dirs (not Default/update). update_bot wipes BOT_DIR.
+VPNBOT_BACKUP="/tmp/mirza_vpnbot_backup"
+
+backup_vpnbots() {
+    local bot_dir="$1" src="$bot_dir/vpnbot" d name
+    mkdir -p "$VPNBOT_BACKUP" || return 1
+    [ -d "$src" ] || return 0
+    for d in "$src"/*; do
+        [ -d "$d" ] || continue
+        name=$(basename "$d")
+        case "$name" in Default|update) continue ;; esac
+        rm -rf "$VPNBOT_BACKUP/$name"
+        cp -a "$d" "$VPNBOT_BACKUP/$name" || return 1
+    done
+    return 0
+}
+export -f backup_vpnbots
+export VPNBOT_BACKUP
+
+restore_vpnbots() {
+    local bot_dir="$1" dest="$bot_dir/vpnbot" update_dir="$bot_dir/vpnbot/update" d name
+    [ -d "$VPNBOT_BACKUP" ] || return 0
+    mkdir -p "$dest" || return 1
+    shopt -s nullglob
+    for d in "$VPNBOT_BACKUP"/*; do
+        [ -d "$d" ] || continue
+        name=$(basename "$d")
+        case "$name" in Default|update) continue ;; esac
+        rm -rf "$dest/$name"
+        cp -a "$d" "$dest/$name" || { shopt -u nullglob; return 1; }
+        if [ -d "$update_dir" ]; then
+            find "$update_dir" -mindepth 1 -maxdepth 1 \
+                ! -name config.php ! -name product.json ! -name product_name.json ! -name data \
+                -exec cp -a {} "$dest/$name/" \;
+        fi
+    done
+    shopt -u nullglob
+    rm -rf "$VPNBOT_BACKUP"
+    return 0
+}
+export -f restore_vpnbots
+
+set_vpnbot_webhooks() {
+    local config="$1"
+    [ -f "$config" ] || return 0
+    local dbhost dbname dbuser dbpass domain rows id user token fail=0
+    dbhost=$(grep '^\$dbhost' "$config" | cut -d"'" -f2)
+    dbname=$(grep '^\$dbname' "$config" | cut -d"'" -f2)
+    dbuser=$(grep '^\$usernamedb' "$config" | cut -d"'" -f2)
+    dbpass=$(grep '^\$passworddb' "$config" | cut -d"'" -f2)
+    domain=$(grep '^\$domainhosts' "$config" | cut -d"'" -f2 | cut -d'/' -f1)
+    [ -z "$dbhost" ] && dbhost="localhost"
+    [ -n "$dbname" ] && [ -n "$dbuser" ] && [ -n "$domain" ] || return 0
+    command -v mysql >/dev/null 2>&1 || return 0
+    rows=$(mysql -h "$dbhost" -u "$dbuser" -p"$dbpass" -N -B \
+        -e "SELECT id_user, username, bot_token FROM botsaz;" "$dbname" 2>/dev/null) || return 0
+    [ -n "$rows" ] || return 0
+    while IFS=$'\t' read -r id user token; do
+        [ -n "$id" ] && [ -n "$user" ] && [ -n "$token" ] || continue
+        curl -s --max-time 15 -o /dev/null \
+            -F "url=https://${domain}/vpnbot/${id}${user}/index.php" \
+            "https://api.telegram.org/bot${token}/setWebhook" || fail=$((fail + 1))
+    done <<< "$rows"
+    [ "$fail" -eq 0 ]
+}
+export -f set_vpnbot_webhooks
+
 # Whole-server pre-flight before installing
 preflight() {
     local ok=1
@@ -2260,8 +2330,13 @@ function update_bot() {
     else
         echo -e "\e[93mWarning: config.php not found. Proceeding without backup.\033[0m"
     fi
+    run_step "Backing up vpnbots" "backup_vpnbots '$BOT_DIR'" \
+        || { show_step_error
+             echo -e "\e[91mError: Failed to backup vpnbots.\033[0m"
+             rm -rf "$TEMP_DIR"; sleep 2; show_menu; return 1; }
     sudo rm -rf "$BOT_DIR" || {
         echo -e "\e[91mFailed to remove old bot files!\033[0m"
+        echo -e "\e[93mvpnbot backup: ${VPNBOT_BACKUP}\033[0m"
         exit 1
     }
     sudo mkdir -p "$BOT_DIR"
@@ -2269,15 +2344,20 @@ function update_bot() {
     purge_installer_dir "$BOT_DIR"
     sudo mv "$EXTRACTED_DIR"/* "$BOT_DIR/" || {
         echo -e "\e[91mFile transfer failed!\033[0m"
+        echo -e "\e[93mvpnbot backup: ${VPNBOT_BACKUP}\033[0m"
         exit 1
     }
     purge_installer_dir "$BOT_DIR"
     if [ -f "$TEMP_CONFIG" ]; then
         sudo mv "$TEMP_CONFIG" "$CONFIG_PATH" || {
             echo -e "\e[91mConfig file restore failed!\033[0m"
+            echo -e "\e[93mvpnbot backup: ${VPNBOT_BACKUP}\033[0m"
             exit 1
         }
     fi
+    run_step "Restoring vpnbots" "restore_vpnbots '$BOT_DIR'" \
+        || { show_step_error
+             echo -e "\e[91mError: Failed to restore vpnbots. Backup: ${VPNBOT_BACKUP}\033[0m"; }
     if [ -f "$BOT_DIR/install.sh" ]; then
         sed -i 's/\r$//' "$BOT_DIR/install.sh"
         if bash -n "$BOT_DIR/install.sh" 2>/dev/null; then
@@ -2363,6 +2443,8 @@ EOF
             run_step "Updating database tables" "curl -s 'https://$URL_PATH/table.php' > /dev/null" \
                 || echo -e "\e[91mSetup script execution failed! Check logs.\033[0m"
         fi
+        run_step "Setting vpnbot webhooks" "set_vpnbot_webhooks '$CONFIG_PATH'" \
+            || echo -e "\e[93mWarning: vpnbot webhook update failed.\033[0m"
     fi
     rm -rf "$TEMP_DIR"
     echo -e "\n\e[92mMirza Bot updated to latest version successfully!\033[0m"

--- a/install.sh
+++ b/install.sh
@@ -1537,25 +1537,44 @@ purge_installer_dir() {
 # vpnbot instance dirs (not Default/update). update_bot wipes BOT_DIR.
 VPNBOT_BACKUP="/tmp/mirza_vpnbot_backup"
 
+vpnbot_instance_count() {
+    local dir="$1" n=0 d
+    [ -d "$dir" ] || { echo 0; return 0; }
+    for d in "$dir"/*; do
+        [ -d "$d" ] || continue
+        case "$(basename "$d")" in Default|update) continue ;; esac
+        n=$((n + 1))
+    done
+    echo "$n"
+}
+export -f vpnbot_instance_count
+
 backup_vpnbots() {
-    local bot_dir="$1" src="$bot_dir/vpnbot" d name
+    local bot_dir="$1"
+    local src="$bot_dir/vpnbot"
+    local d name count=0
     mkdir -p "$VPNBOT_BACKUP" || return 1
-    [ -d "$src" ] || return 0
+    [ -d "$src" ] || { echo "Backed up 0 vpnbot(s)"; return 0; }
     for d in "$src"/*; do
         [ -d "$d" ] || continue
         name=$(basename "$d")
         case "$name" in Default|update) continue ;; esac
         rm -rf "$VPNBOT_BACKUP/$name"
         cp -a "$d" "$VPNBOT_BACKUP/$name" || return 1
+        count=$((count + 1))
     done
+    echo "Backed up $count vpnbot(s)"
     return 0
 }
 export -f backup_vpnbots
 export VPNBOT_BACKUP
 
 restore_vpnbots() {
-    local bot_dir="$1" dest="$bot_dir/vpnbot" update_dir="$bot_dir/vpnbot/update" d name
-    [ -d "$VPNBOT_BACKUP" ] || return 0
+    local bot_dir="$1"
+    local dest="$bot_dir/vpnbot"
+    local update_dir="$bot_dir/vpnbot/update"
+    local d name count=0
+    [ -d "$VPNBOT_BACKUP" ] || { echo "No vpnbot backup to restore"; return 0; }
     mkdir -p "$dest" || return 1
     shopt -s nullglob
     for d in "$VPNBOT_BACKUP"/*; do
@@ -1569,9 +1588,10 @@ restore_vpnbots() {
                 ! -name config.php ! -name product.json ! -name product_name.json ! -name data \
                 -exec cp -a {} "$dest/$name/" \;
         fi
+        count=$((count + 1))
     done
     shopt -u nullglob
-    rm -rf "$VPNBOT_BACKUP"
+    echo "Restored $count vpnbot(s)"
     return 0
 }
 export -f restore_vpnbots
@@ -2334,6 +2354,12 @@ function update_bot() {
         || { show_step_error
              echo -e "\e[91mError: Failed to backup vpnbots.\033[0m"
              rm -rf "$TEMP_DIR"; sleep 2; show_menu; return 1; }
+    _vpnbot_live=$(vpnbot_instance_count "$BOT_DIR/vpnbot")
+    _vpnbot_bak=$(vpnbot_instance_count "$VPNBOT_BACKUP")
+    if [ "$_vpnbot_live" -gt 0 ] && [ "$_vpnbot_bak" -lt "$_vpnbot_live" ]; then
+        echo -e "\e[91mError: vpnbot backup incomplete ($_vpnbot_bak/$_vpnbot_live). Update aborted.\033[0m"
+        rm -rf "$TEMP_DIR"; sleep 2; show_menu; return 1
+    fi
     sudo rm -rf "$BOT_DIR" || {
         echo -e "\e[91mFailed to remove old bot files!\033[0m"
         echo -e "\e[93mvpnbot backup: ${VPNBOT_BACKUP}\033[0m"
@@ -2358,6 +2384,12 @@ function update_bot() {
     run_step "Restoring vpnbots" "restore_vpnbots '$BOT_DIR'" \
         || { show_step_error
              echo -e "\e[91mError: Failed to restore vpnbots. Backup: ${VPNBOT_BACKUP}\033[0m"; }
+    _vpnbot_restored=$(vpnbot_instance_count "$BOT_DIR/vpnbot")
+    if [ "$_vpnbot_bak" -gt 0 ] && [ "$_vpnbot_restored" -lt "$_vpnbot_bak" ]; then
+        echo -e "\e[91mError: vpnbot restore incomplete ($_vpnbot_restored/$_vpnbot_bak). Backup kept at ${VPNBOT_BACKUP}\033[0m"
+    else
+        rm -rf "$VPNBOT_BACKUP"
+    fi
     if [ -f "$BOT_DIR/install.sh" ]; then
         sed -i 's/\r$//' "$BOT_DIR/install.sh"
         if bash -n "$BOT_DIR/install.sh" 2>/dev/null; then


### PR DESCRIPTION
The update process had a problem, which was that after each update, the code of the agent bots was deleted by the script and they could no longer be activated, and we had to delete and reinstall the bot for each agent.

Now, the problem has been solved in this update and has also been tested on the agent robot.