### PR TITLE
Update function.php افزودن پارامتر اختیاری redirect_after_payment برای CubePay

### DIFF
--- a/function.php
+++ b/function.php
@@ -819,6 +819,7 @@ function trnado($order_id, $price)
         'price_amount' => $amount_toman,
         'order_id' => $order_id,
         'callback_url' => "https://$domainhosts/payment/iranpay2.php",
+        'redirect_after_payment' => false,
     ], JSON_UNESCAPED_UNICODE));
 
     $response = curl_exec($curl);


### PR DESCRIPTION
سرویسِ پرداختِ CubePay یه قابلیتِ جدید اضافه کرده: پارامترِ اختیاریِ redirect_after_payment. وقتی این مقدار false فرستاده بشه، بعد از تاییدِ پرداخت، مرورگرِ مشتری به دامنه‌ی فروشنده ریدایرکت نمی‌شه — چون Mirzabot یه رباتِ تلگرامیه و نتیجه‌ی پرداخت رو از طریقِ پیامِ ربات (نه مرورگر) به مشتری اطلاع می‌ده، این ریدایرکتِ اضافه بی‌مورد بود و آدرسِ دامنه‌ی فروشنده رو بی‌دلیل به مشتری نشون می‌داد.

این تغییر فقط یک خط اضافه می‌کنه و کاملاً اختیاریه — رفتارِ پیش‌فرض برای بقیه‌ی درگاه‌ها یا فروشنده‌هایی که این گزینه رو فعال نکردن، بدونِ هیچ تغییری می‌مونه.

---
English summary: CubePay now supports an optional redirect_after_payment parameter. Setting it to false skips the post-payment browser redirect to the merchant's domain — appropriate for Telegram bots like Mirzabot, which already notify the customer of payment success via a bot message rather than a browser redirect. This is a single-line, fully backward-compatible addition.