### PR TITLE
Fix missing volume units in service notifications cron

### DIFF
--- a/cronbot/NoticationsService.php
+++ b/cronbot/NoticationsService.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../config.php';
 require_once __DIR__ . '/../botapi.php';
 require_once __DIR__ . '/../panels.php';
 require_once __DIR__ . '/../function.php';
+$textbotlang = languagechange();
 class ServiceMonitor
 {
     private $Panel;


### PR DESCRIPTION
### Problem
The `formatBytes()` helper function in `function.php` depends on the global `$textbotlang` variable to append data unit suffixes (e.g., Megabyte, Gigabyte). In `cronbot/NoticationsService.php`, `$textbotlang` was not initialized at the global scope, resulting in volume threshold alerts being sent without any unit labels (e.g., displaying `821.52` instead of `821.52 مگابایت`).

### Solution
Initialized `$textbotlang = languagechange();` at the file level in `cronbot/NoticationsService.php`, matching the established pattern across all other scripts in the `cronbot/` directory (`backupbot.php`, `statusday.php`, etc.).
